### PR TITLE
accept non-numeric version

### DIFF
--- a/cmd/manager/main.go
+++ b/cmd/manager/main.go
@@ -35,6 +35,14 @@ func printVersion() {
 	log.Info(fmt.Sprintf("operator-sdk Version: %v", sdkVersion.Version))
 }
 
+func getCleanVersion(version string) (string, error) {
+    reg, err := regexp.Compile("[^0-9]+")
+    if err != nil {
+		return "", err
+    }
+	return reg.ReplaceAllString(version, ""), nil
+}
+
 func main() {
 	flag.Parse()
 
@@ -68,11 +76,11 @@ func main() {
 			os.Exit(1)
 		}
 		var major, minor int
-		if major, err = strconv.Atoi(serverVersion.Major); err != nil {
+		if major, err = strconv.Atoi(getCleanVersionserverVersion.Major); err != nil {
 			log.Error(err, "")
 			os.Exit(1)
 		}
-		if minor, err = strconv.Atoi(serverVersion.Minor); err != nil {
+		if minor, err = strconv.Atoi(getCleanVersion(serverVersion.Minor)); err != nil {
 			log.Error(err, "")
 			os.Exit(1)
 		}


### PR DESCRIPTION
`$ kubectl logs -f kanary-7c5b568bbc-k9fsd       
{"level":"info","ts":1559833517.2926314,"logger":"cmd","msg":"Go Version: go1.12.4"}
{"level":"info","ts":1559833517.2928202,"logger":"cmd","msg":"Go OS/Arch: linux/amd64"}
{"level":"info","ts":1559833517.2929137,"logger":"cmd","msg":"operator-sdk Version: v0.3.0+git"}
{"level":"error","ts":1559833517.3085406,"logger":"cmd","msg":"","error":"strconv.Atoi: parsing \"13+\": invalid syntax","stacktrace":"github.com/amadeusitgroup/kanary/vendor/github.com/go-logr/zapr.(*zapLogger).Error\n\t/Users/cedric.lamoriniere/dev/perso/src/github.com/amadeusitgroup/kanary/vendor/github.com/go-logr/zapr/zapr.go:128\nmain.main\n\t/Users/cedric.lamoriniere/dev/perso/src/github.com/amadeusitgroup/kanary/cmd/manager/main.go:76\nruntime.main\n\t/usr/local/Cellar/go/1.12.4/libexec/src/runtime/proc.go:200"}
`

`$ kubectl version
Client Version: version.Info{Major:"1", Minor:"13", GitVersion:"v1.13.4", GitCommit:"c27b913fddd1a6c480c229191a087698aa92f0b1", GitTreeState:"clean", BuildDate:"2019-02-28T13:37:52Z", GoVersion:"go1.11.5", Compiler:"gc", Platform:"linux/amd64"}
Server Version: version.Info{Major:"1", Minor:"13+", GitVersion:"v1.13.6-gke.0", GitCommit:"14c9138d6fb5b57473e270fe8a2973300fbd6fd6", GitTreeState:"clean", BuildDate:"2019-05-08T16:22:55Z", GoVersion:"go1.11.5b4", Compiler:"gc", Platform:"linux/amd64"}
`